### PR TITLE
Properly escape shell arguments in pytry-many

### DIFF
--- a/pytry/many.py
+++ b/pytry/many.py
@@ -1,12 +1,17 @@
 import sys
 import os
 
+# Imoprt shlex.quote when using Python 3, pipes.quote when using Python 2
+try:
+    from shlex import quote
+except ImportError:
+    from pipes import quote
 
 def execute(cmd, checked=None):
     if checked is None:
         checked = []
     if len(cmd) == 0:
-        os.system(' '.join(checked))
+        os.system(' '.join(map(quote, checked)))
     else:
         c = cmd.pop(0)
         if c.startswith('[') and c.endswith(']'):


### PR DESCRIPTION
When using os.system (or really, just any kind of shell scripting), it is of utmost importance to properly escape individual arguments. For example

    pytry-many echo 'Hello World'

must be substituted to

    echo 'Hello World'

and not

    echo Hello World

This commit fixes this problem by properly escaping individual arguments. Note that this also prevents accidental execution of commands, such as

    pytry-many echo '`rm *`'